### PR TITLE
Avoid keeping build-time dependencies in final container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,15 +31,15 @@ RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-
     zip \
     unzip \
     perl-base && \
-  && R -e 'install.packages(c("irlba","igraph","XML","intervals"), repos="https://mirrors.ebi.ac.uk/CRAN/")' \
-  && R -e 'install.packages("devtools", repos="https://mirrors.ebi.ac.uk/CRAN/")' \
-  && R -e 'library(BiocInstaller); biocLite("multtest")' \
-  && R -e 'install.packages(c("RColorBrewer","Hmisc","gplots","multcomp","rgl","mixOmics","vegan","cba","nlme","ape","pvclust","dendextend","phangorn","VennDiagram"), repos="https://mirrors.ebi.ac.uk/CRAN/")' \
-  && apt-get -y remove --purge \
+    R -e 'install.packages(c("irlba","igraph","XML","intervals"), repos="https://cran.r-project.org/")' && \
+    R -e 'install.packages("devtools", repos="https://cran.r-project.org/")' && \
+    R -e 'library(BiocInstaller); biocLite("multtest")' && \
+    R -e 'install.packages(c("RColorBrewer","Hmisc","gplots","multcomp","rgl","mixOmics","vegan","cba","nlme","ape","pvclust","dendextend","phangorn","VennDiagram"), repos="https://cran.r-project.org/")' && \
+    apt-get -y remove --purge \
                 g++ \
                 gcc \
-                gfortran \
-  && apt-get -y clean && apt-get -y autoremove && rm -rf /var/lib/{cache,log}/ /tmp/* /var/tmp/*
+                gfortran && \
+    apt-get -y clean && apt-get -y autoremove && rm -rf /var/lib/{cache,log}/ /tmp/* /var/tmp/*
 
 # Add scripts to container
 ADD scripts/* /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,33 +11,46 @@ LABEL documentation="https://github.com/phnmnl/container-ecomet/blob/master/READ
 LABEL license="https://github.com/phnmnl/container-midcor/blob/master/License.txt"
 LABEL tags="Metabolomics,Ecology"
 
-# Install packages for compilation
-RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install apt-transport-https \
-    make \
-    gcc \
-    gfortran \
-    g++ \
-    libnetcdf-dev \
-    libxml2-dev \
-    libblas-dev \
-    liblapack-dev \
-    libssl-dev \
-    pkg-config \
-    git \
-    xorg \
-    xorg-dev \
-    libglu1-mesa-dev \
-    libgl1-mesa-dev \
-    wget \
-    zip \
-    unzip \
-    perl-base && \
-    R -e 'install.packages(c("irlba","igraph","XML","intervals"), repos="https://cran.r-project.org/")' && \
-    R -e 'install.packages("devtools", repos="https://cran.r-project.org/")' && \
-    R -e 'library(BiocInstaller); biocLite("multtest")' && \
-    R -e 'install.packages(c("RColorBrewer","Hmisc","gplots","multcomp","rgl","mixOmics","vegan","cba","nlme","ape","pvclust","dendextend","phangorn","VennDiagram"), repos="https://cran.r-project.org/")'
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get -y clean && apt-get -y autoremove && rm -rf /var/lib/{cache,log}/ /tmp/* /var/tmp/*
+RUN \
+     apt-get -y update \
+  && apt-get -y --no-install-recommends \
+             install \
+                apt-transport-https \
+                g++ \
+                gcc \
+                gfortran \
+                git \
+                libblas3 \
+                libblas-dev \
+                liblapack-dev \
+                libnetcdf-dev \
+                libssl1.0.0 \
+                libssl-dev \
+                libxml2 \
+                libxml2-dev \
+                make \
+                perl-base \
+                pkg-config \
+                unzip \
+                wget \
+                zip \
+  && R -e 'install.packages(c("irlba","igraph","XML","intervals"), repos="https://mirrors.ebi.ac.uk/CRAN/")' \
+  && R -e 'install.packages("devtools", repos="https://mirrors.ebi.ac.uk/CRAN/")' \
+  && R -e 'library(BiocInstaller); biocLite("multtest")' \
+  && R -e 'install.packages(c("RColorBrewer","Hmisc","gplots","multcomp","rgl","mixOmics","vegan","cba","nlme","ape","pvclust","dendextend","phangorn","VennDiagram"), repos="https://mirrors.ebi.ac.uk/CRAN/")' \
+  && apt-get -y remove --purge \
+                g++ \
+                gcc \
+                gfortran \
+                git \
+                libblas-dev \
+                libssl-dev \
+                libxml2-dev \
+                make \
+                pkg-config \
+  && apt-get -y clean && apt-get -y autoremove && rm -rf /var/lib/{cache,log}/ /tmp/* /var/tmp/*
 
 # Add scripts to container
 ADD scripts/* /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,31 +11,26 @@ LABEL documentation="https://github.com/phnmnl/container-ecomet/blob/master/READ
 LABEL license="https://github.com/phnmnl/container-midcor/blob/master/License.txt"
 LABEL tags="Metabolomics,Ecology"
 
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN \
-     apt-get -y update \
-  && apt-get -y --no-install-recommends \
-             install \
-                apt-transport-https \
-                g++ \
-                gcc \
-                gfortran \
-                git \
-                libblas3 \
-                libblas-dev \
-                liblapack-dev \
-                libnetcdf-dev \
-                libssl1.0.0 \
-                libssl-dev \
-                libxml2 \
-                libxml2-dev \
-                make \
-                perl-base \
-                pkg-config \
-                unzip \
-                wget \
-                zip \
+RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install apt-transport-https \
+    make \
+    gcc \
+    gfortran \
+    g++ \
+    libnetcdf-dev \
+    libxml2-dev \
+    libblas-dev \
+    liblapack-dev \
+    libssl-dev \
+    pkg-config \
+    git \
+    xorg \
+    xorg-dev \
+    libglu1-mesa-dev \
+    libgl1-mesa-dev \
+    wget \
+    zip \
+    unzip \
+    perl-base && \
   && R -e 'install.packages(c("irlba","igraph","XML","intervals"), repos="https://mirrors.ebi.ac.uk/CRAN/")' \
   && R -e 'install.packages("devtools", repos="https://mirrors.ebi.ac.uk/CRAN/")' \
   && R -e 'library(BiocInstaller); biocLite("multtest")' \
@@ -44,12 +39,6 @@ RUN \
                 g++ \
                 gcc \
                 gfortran \
-                git \
-                libblas-dev \
-                libssl-dev \
-                libxml2-dev \
-                make \
-                pkg-config \
   && apt-get -y clean && apt-get -y autoremove && rm -rf /var/lib/{cache,log}/ /tmp/* /var/tmp/*
 
 # Add scripts to container


### PR DESCRIPTION
This PR approximately halves the container image size, down to just under 1 GB, by not keeping build-time dependencies in the final image.  While the container builds successfully, I don't have a deployment available with sufficient memory to test the workflow.  Please test before merging.